### PR TITLE
ProjectManagement additions, recording integration w/ playback, and recording padding

### DIFF
--- a/Source/AudioRecorder.cpp
+++ b/Source/AudioRecorder.cpp
@@ -11,6 +11,7 @@
 */
 
 #include "AudioRecorder.h"
+#include "MixdownFolder.h"
 
 
 //===================================== AudioRecorder =========================================
@@ -258,6 +259,9 @@ void LayerRecorderComponent::setProject(Project *p) {
 void LayerRecorderComponent::setTransport(juce::AudioTransportSource* ats) {
     this->transport = ats;
 }
+void LayerRecorderComponent::setPlaybackComp(MixdownFolderComp* playbackComp) {
+    this->playbackComp = playbackComp;
+}
 
 void LayerRecorderComponent::startRecording() {
     if (! juce::RuntimePermissions::isGranted (juce::RuntimePermissions::writeExternalStorage)) {
@@ -272,6 +276,8 @@ void LayerRecorderComponent::startRecording() {
 
     Layer newLayer = currProject->createNewLayer();
     recorder.startRecording (newLayer.getFile(), transport->getCurrentPosition());
+    isCurrentlyRecording = true;
+    playbackComp->triggerPlayback();
 
     recordButton.setButtonText ("Stop");
     recordingThumbnail.setDisplayFullThumbnail (false);
@@ -279,6 +285,7 @@ void LayerRecorderComponent::startRecording() {
 
 void LayerRecorderComponent::stopRecording() {
     recorder.stopRecording();
+    isCurrentlyRecording = false;
     recordButton.setButtonText ("Record");
     recordingThumbnail.setDisplayFullThumbnail (true);
 }

--- a/Source/AudioRecorder.cpp
+++ b/Source/AudioRecorder.cpp
@@ -30,7 +30,7 @@ void AudioRecorder::startRecording(const juce::File& file) {
     
     if (sampleRate <= 0) return;
     
-    // file.deleteFile(); // potentially dangerous and unnecessary
+    file.deleteFile();
     
     // Open filestream to write to destination file
     if (auto fileStream = std::unique_ptr<juce::FileOutputStream>(file.createOutputStream())) {
@@ -52,7 +52,7 @@ void AudioRecorder::startRecording(const juce::File& file) {
             const juce::ScopedLock sl (writerLock);
             activeWriter = threadedWriter.get();
         }
-    }
+    } else throw "Unable to open provided file";
 }
 
 void AudioRecorder::stopRecording() {
@@ -84,7 +84,7 @@ void AudioRecorder::audioDeviceIOCallback (const float** inputChannelData, int n
                             float** outputChannelData, int numOutputChannels,
                             int numSamples) {
     
-    const juce::ScopedLock sl(AudioRecorder::writerLock); // why is "AudioRecorder::" necessary here?
+    const juce::ScopedLock sl(AudioRecorder::writerLock);
 
     if (activeWriter.load() != nullptr && numInputChannels >= thumbnail.getNumChannels()) // This seems funky; why would we compare numInput channels with the thumbnail channels? I thought the thumbnail was just used for painting waveforms @Nolan
     {

--- a/Source/AudioRecorder.h
+++ b/Source/AudioRecorder.h
@@ -172,6 +172,8 @@ public:
      */
     void setTransport(juce::AudioTransportSource*);
     
+    void stopRecording();
+    
 private:
     juce::AudioDeviceManager& audioDeviceManager;
     
@@ -186,7 +188,6 @@ private:
     juce::AudioTransportSource* transport;
     
     void startRecording();
-    void stopRecording();
     
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (LayerRecorderComponent)
 };

--- a/Source/AudioRecorder.h
+++ b/Source/AudioRecorder.h
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <JuceHeader.h>
+#include "ProjectManagement.h"
 
 
 /** A simple class that acts as an AudioIODeviceCallback and writes the
@@ -143,19 +144,25 @@ public:
 
 
 /**
- The top-level component which houses the other components necessary for recording audio.
+ The top-level component which houses the other components necessary for recording layers.
  */
-class AudioRecorderComponent : public juce::Component {
+class LayerRecorderComponent : public juce::Component {
 public:
     /**
-     Create a new AudioRecorderComponent
-     @param adm     The audio device manager which this AudioRecorderComponent will use to recieve audio input and send audio output from selected audio devices.
+     Create a new LayerRecorderComponent
+     @param adm     The audio device manager which this LayerRecorderComponent will use to recieve audio input and send audio output from selected audio devices.
      */
-    AudioRecorderComponent(juce::AudioDeviceManager& adm);
-    ~AudioRecorderComponent() override;
+    LayerRecorderComponent(juce::AudioDeviceManager& adm);
+    ~LayerRecorderComponent() override;
     
     void paint(juce::Graphics& g) override;
     void resized() override;
+    
+    /**
+     Sets a Project for this LayerRecorderComponent to focus on and record layers to.
+     @param p   A pointer to a Project.
+     */
+    void setProject(Project* p);
     
 private:
     juce::AudioDeviceManager& audioDeviceManager;
@@ -164,15 +171,15 @@ private:
     RecordingThumbnail recordingThumbnail;
     AudioRecorder recorder { recordingThumbnail.getAudioThumbnail() };
     
-    juce::Label explanationLabel { {}, "Record a wave file from the live audio input.\n\nPressing record will start recording a file in your \"Documents\" folder."};
+    juce::Label explanationLabel { {}, "No project loaded"};
     juce::TextButton recordButton { "Record" };
-    juce::File lastRecording;
+    
+    Project* currProject; // The Project which this LayerRecorderComponent is currently recording layers to
     
     void startRecording();
-    
     void stopRecording();
     
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (AudioRecorderComponent)
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (LayerRecorderComponent)
 };
 
 

--- a/Source/AudioRecorder.h
+++ b/Source/AudioRecorder.h
@@ -152,7 +152,7 @@ public:
      Create a new LayerRecorderComponent
      @param adm     The audio device manager which this LayerRecorderComponent will use to recieve audio input and send audio output from selected audio devices.
      */
-    LayerRecorderComponent(juce::AudioDeviceManager& adm);
+    LayerRecorderComponent(juce::AudioDeviceManager&);
     ~LayerRecorderComponent() override;
     
     void paint(juce::Graphics& g) override;
@@ -163,6 +163,12 @@ public:
      @param p   A pointer to a Project.
      */
     void setProject(Project* p);
+    
+    /**
+     Sets the transport source to reference so that the start time of a layer recording relative to it's project's mixdown can be saved.
+     This is admittedly bad practice, and indicative of architectural flaws.
+     */
+    void setTransport(juce::AudioTransportSource*);
     
 private:
     juce::AudioDeviceManager& audioDeviceManager;
@@ -175,9 +181,14 @@ private:
     juce::TextButton recordButton { "Record" };
     
     Project* currProject; // The Project which this LayerRecorderComponent is currently recording layers to
+    juce::AudioTransportSource* transport;
+    double posOfLastRecordStart; // time position (relative to project's mixdown) that the last recording was started
+    juce::AudioFormatManager audioFormatManager;
+    juce::WavAudioFormat wavAudioFormat;
     
     void startRecording();
     void stopRecording();
+    void padRecording();
     
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (LayerRecorderComponent)
 };

--- a/Source/AudioRecorder.h
+++ b/Source/AudioRecorder.h
@@ -32,7 +32,7 @@ public:
      Begin recording.
      @param file    File to record to.
      */
-    void startRecording(const juce::File& file);
+    void startRecording(const juce::File& file, double paddingTime=0.0);
     
     /**
      Stop recording.
@@ -65,6 +65,8 @@ public:
                                 int numSamples) override;
     
 private:
+    void padRecording(juce::AudioFormatWriter*, double paddingTime);
+    
     juce::AudioThumbnail& thumbnail; // for drawing scaled view of audio waveform
     juce::TimeSliceThread backgroundThread { "Audio Recorder Thread" }; // this thread writes audio data to disk
     std::unique_ptr<juce::AudioFormatWriter::ThreadedWriter> threadedWriter; // FIFO buffer for incoming data
@@ -182,13 +184,9 @@ private:
     
     Project* currProject; // The Project which this LayerRecorderComponent is currently recording layers to
     juce::AudioTransportSource* transport;
-    double posOfLastRecordStart; // time position (relative to project's mixdown) that the last recording was started
-    juce::AudioFormatManager audioFormatManager;
-    juce::WavAudioFormat wavAudioFormat;
     
     void startRecording();
     void stopRecording();
-    void padRecording();
     
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (LayerRecorderComponent)
 };

--- a/Source/AudioRecorder.h
+++ b/Source/AudioRecorder.h
@@ -14,6 +14,7 @@
 
 #include <JuceHeader.h>
 #include "ProjectManagement.h"
+class MixdownFolderComp;
 
 
 /** A simple class that acts as an AudioIODeviceCallback and writes the
@@ -171,8 +172,12 @@ public:
      This is admittedly bad practice, and indicative of architectural flaws.
      */
     void setTransport(juce::AudioTransportSource*);
+    void setPlaybackComp(MixdownFolderComp*);
     
+    void startRecording();
     void stopRecording();
+    
+    bool isRecording() { return isCurrentlyRecording; }
     
 private:
     juce::AudioDeviceManager& audioDeviceManager;
@@ -184,10 +189,11 @@ private:
     juce::Label explanationLabel { {}, "No project loaded"};
     juce::TextButton recordButton { "Record" };
     
+    bool isCurrentlyRecording;
+    
+    MixdownFolderComp* playbackComp;
     Project* currProject; // The Project which this LayerRecorderComponent is currently recording layers to
     juce::AudioTransportSource* transport;
-    
-    void startRecording();
     
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (LayerRecorderComponent)
 };

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -18,7 +18,7 @@ MainComponent::MainComponent()
     addAndMakeVisible(layerRecorderComp);
     // This is certainly bad practice, but alternatives require radical redesign
     layerRecorderComp.setTransport(mixdownFolderComp.getTransportPtr());
-        
+    layerRecorderComp.setPlaybackComp(&mixdownFolderComp);
     addAndMakeVisible(audioSetupComp);
         
     addAndMakeVisible(mixdownFolderComp);

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -11,11 +11,11 @@ MainComponent::MainComponent()
                   false, // ability to select midi output devi
                   false, // treat channels as stereo pairs
                   true),// hide advanced options
-        recorderComponent(deviceManager),
-        mixdownFolderComp(deviceManager)
+        layerRecorderComp(deviceManager),
+        mixdownFolderComp(deviceManager, layerRecorderComp)
     {
-            
-    addAndMakeVisible(recorderComponent);
+        
+    addAndMakeVisible(layerRecorderComp);
         
     addAndMakeVisible(audioSetupComp);
         
@@ -78,7 +78,7 @@ void MainComponent::resized() {
     grid.templateColumns = { Track (Fr (4)), Track (Fr (3)) };
     
     grid.items = {
-        juce::GridItem(recorderComponent), juce::GridItem(audioSetupComp),
+        juce::GridItem(layerRecorderComp), juce::GridItem(audioSetupComp),
         juce::GridItem(mixdownFolderComp)
     };
     

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -16,6 +16,8 @@ MainComponent::MainComponent()
     {
         
     addAndMakeVisible(layerRecorderComp);
+    // This is certainly bad practice, but alternatives require radical redesign
+    layerRecorderComp.setTransport(mixdownFolderComp.getTransportPtr());
         
     addAndMakeVisible(audioSetupComp);
         
@@ -34,7 +36,6 @@ MainComponent::MainComponent()
     
     setAudioChannels(2, 2); // This could be more sophisticated to handle unconvential input/output setups
     deviceManager.addChangeListener(this);
-    
 }
 
 /**

--- a/Source/MainComponent.h
+++ b/Source/MainComponent.h
@@ -31,7 +31,7 @@ private:
     //==============================================================================
     // Your private member variables go here...
     juce::AudioDeviceSelectorComponent audioSetupComp;
-    AudioRecorderComponent recorderComponent;
+    LayerRecorderComponent layerRecorderComp;
     MixdownFolderComp mixdownFolderComp;
     juce::TextEditor diagnosticsBox;
     

--- a/Source/MixdownFolder.cpp
+++ b/Source/MixdownFolder.cpp
@@ -170,7 +170,7 @@ void MixdownFolderComp::stateChange(TransportState newState) {
 */
 void MixdownFolderComp::fileBoxMenuChanged() {
     int fileID = fileBoxMenu.getSelectedId();
-    if (projects.size() == 0) return;
+    if (fileID == 0) return;
     //fileBoxMenu indices starts at 1 but array indices start at 0
     Project& selected = projects.getReference(fileID-1);
     layerRecorder.setProject(&selected);

--- a/Source/MixdownFolder.cpp
+++ b/Source/MixdownFolder.cpp
@@ -210,10 +210,7 @@ void MixdownFolderComp::fileBoxMenuChanged() {
 * Audio files are loaded into fileBoxMenu
 */
 void MixdownFolderComp::fileButtonClickResponse() {
-    //"userMusicDirectory" redirects to windows default music directory
-    juce::FileChooser fileChooser("Choose a mixdown folder",
-        juce::File::getSpecialLocation(juce::File::userMusicDirectory));
-
+    juce::FileChooser fileChooser("Choose a mixdown folder");
     //Awaits user directory selection
     if (fileChooser.browseForDirectory()) {
         juce::File myDirectory;

--- a/Source/MixdownFolder.cpp
+++ b/Source/MixdownFolder.cpp
@@ -52,7 +52,10 @@ MixdownFolderComp::MixdownFolderComp(juce::AudioDeviceManager& adm, LayerRecorde
     stopButton.setButtonText("Stop");
     stopButton.setColour(juce::TextButton::buttonColourId, juce::Colours::blue);
     //Lambda captures event on button click and calls function
-    stopButton.onClick = [this] {stopButtonClickResponse(); };
+    stopButton.onClick = [this] {
+        stopButtonClickResponse();
+        this->layerRecorder.stopRecording();
+    };
     stopButton.setEnabled(false);
 
     //Registers the basic format of WAV and RIFF files

--- a/Source/MixdownFolder.cpp
+++ b/Source/MixdownFolder.cpp
@@ -166,6 +166,11 @@ void MixdownFolderComp::stateChange(TransportState newState) {
     }
 }
 
+void MixdownFolderComp::triggerPlayback() {
+    if (state != Playing)
+        playButton.triggerClick();
+}
+
 /**
 * Function updates dropdown bar with selected audio file and primes playback.
 * Component state is reverted to state.Stopped if it has been changed.
@@ -177,6 +182,11 @@ void MixdownFolderComp::fileBoxMenuChanged() {
     //fileBoxMenu indices starts at 1 but array indices start at 0
     Project& selected = projects.getReference(fileID-1);
     layerRecorder.setProject(&selected);
+    if (layerRecorder.isRecording()) {
+        // continue recording, but for new project
+        layerRecorder.stopRecording();
+        layerRecorder.startRecording();
+    }
     
     juce::AudioFormatReader* fileReader = audioFormatManager.createReaderFor(selected.getMixdownFile());
 
@@ -189,10 +199,6 @@ void MixdownFolderComp::fileBoxMenuChanged() {
         playButton.setEnabled(true);
 
         reader.reset(tempReader.release());
-    }
-
-    if (state != Stopped) {
-        stateChange(Stopped);
     }
 
     //Set bounds of next/prev buttons
@@ -284,9 +290,10 @@ void MixdownFolderComp::prevButtonClickResponse() {
         prevButton.setEnabled(true);
     }
     
-    // Continue playing (begin playing new track seemlessly)
-    if (lastState == Playing)
+    if (lastState == Playing) {
+        // Continue playing (begin playing new track seemlessly)
         playButton.triggerClick();
+    }
 }
 
 /**

--- a/Source/MixdownFolder.h
+++ b/Source/MixdownFolder.h
@@ -68,6 +68,8 @@ public:
     void resized() override;
                                 
     juce::AudioTransportSource* getTransportPtr() { return &(this->transport); }
+                                
+    void triggerPlayback();
 
 //Variables and enumerations of Mixdown Folder class
 private:

--- a/Source/MixdownFolder.h
+++ b/Source/MixdownFolder.h
@@ -66,6 +66,8 @@ public:
     * Called everytime the MixDownFolder component size is changed.
     */
     void resized() override;
+                                
+    juce::AudioTransportSource* getTransportPtr() { return &(this->transport); }
 
 //Variables and enumerations of Mixdown Folder class
 private:

--- a/Source/MixdownFolder.h
+++ b/Source/MixdownFolder.h
@@ -13,6 +13,9 @@
 
 #include <JuceHeader.h>
 
+#include "ProjectManagement.h"
+#include "AudioRecorder.h"
+
 class MixdownFolderComp :   public juce::Component,
                             public juce::AudioSource,
                             public juce::ChangeListener {
@@ -23,7 +26,8 @@ public:
     /**
     * Acts as constructor to set up necessary variables and functions.
     */
-    MixdownFolderComp(juce::AudioDeviceManager& adm);
+    MixdownFolderComp(juce::AudioDeviceManager& adm, LayerRecorderComponent& layerRecorder);
+    
     /**
     * Mixdown folder destructor.
     */
@@ -84,6 +88,8 @@ private:
     juce::AudioFormatManager audioFormatManager;
     std::unique_ptr<juce::AudioFormatReaderSource> reader;
     juce::AudioTransportSource transport;
+                                
+    LayerRecorderComponent& layerRecorder;
 
     /**
     * Callback function that projects changes audio transport source.
@@ -107,8 +113,7 @@ private:
     void stateChange(TransportState newState);
 
     //Saved audio files for id tracking and file storage
-    juce::Array<juce::File> audioFiles;
-    juce::File selectedAudioFile;
+    juce::Array<Project> projects;
 
     //Audio file storage and event response
     juce::ComboBox fileBoxMenu;

--- a/Source/ProjectManagement.cpp
+++ b/Source/ProjectManagement.cpp
@@ -55,6 +55,7 @@ juce::File Project::getLayerDirectory() {
 
 juce::File Project::createNewLayer() {
     juce::File layerFile = getLayerDirectory().getNonexistentChildFile("layer_" + std::to_string(getNumLayers() + 1), ".wav");
+    layerFile.create();
     layers.add(Layer(layerFile));
     return layerFile;
 }

--- a/Source/ProjectManagement.cpp
+++ b/Source/ProjectManagement.cpp
@@ -12,11 +12,23 @@
 
 #include "ProjectManagement.h"
 
-Layer::Layer(juce::File& file) : layerFile(file) {}
+
+//===================================== Layer =========================================
+
+Layer::Layer(juce::File file) : layerFile(file) {}
 
 bool Layer::operator==(const Layer &other) {
     return layerFile == other.layerFile;
 }
+
+juce::File& Layer::getFile() { return layerFile; }
+
+
+//===================================== Project =========================================
+
+// This seems like bad practice but was necessary to get working with juce::Array. Normally,
+// I would not create a default constructor like this. This should never be called. - Nolan
+Project::Project() : layers(), mixdownFile(juce::File()) {}
 
 Project::Project(juce::File& mixdownFile) : mixdownFile(mixdownFile) {
     if (mixdownFile.isDirectory()) throw "Invalid mixdownFile given; mixdownFile is a directory";
@@ -31,11 +43,33 @@ Project::Project(juce::File& mixdownFile) : mixdownFile(mixdownFile) {
     }
 }
 
+juce::String Project::getName() {
+    return mixdownFile.getFileNameWithoutExtension();
+}
+
+juce::File& Project::getMixdownFile() { return mixdownFile; }
+
+juce::File Project::getLayerDirectory() {
+    return mixdownFile.withFileExtension(juce::StringRef());
+}
+
+juce::File Project::createNewLayer() {
+    juce::File layerFile = getLayerDirectory().getNonexistentChildFile("layer_" + std::to_string(getNumLayers() + 1), ".wav");
+    layers.add(Layer(layerFile));
+    return layerFile;
+}
+
+int Project::getNumLayers() { return layers.size(); }
+
+
+//===================================== ProjectManagement =========================================
+
 juce::Array<Project> ProjectManagement::getAllProjectsInFolder(juce::File &mixdownFolder) {
     juce::Array<Project> projects;
     juce::Array<juce::File> children = mixdownFolder.findChildFiles(juce::File::findFiles, false);
     for (juce::File child : children) {
-        projects.add(Project(child));
+        if (child.getFileExtension().equalsIgnoreCase(".wav"))
+            projects.add(Project(child));
     }
     return projects;
 }

--- a/Source/ProjectManagement.cpp
+++ b/Source/ProjectManagement.cpp
@@ -60,6 +60,10 @@ juce::File Project::createNewLayer() {
     return layerFile;
 }
 
+juce::File Project::getLastLayerFile() {
+    return layers.getReference(layers.size() - 1).getFile();
+}
+
 int Project::getNumLayers() { return layers.size(); }
 
 

--- a/Source/ProjectManagement.h
+++ b/Source/ProjectManagement.h
@@ -15,14 +15,21 @@
 
 class Layer {
 public:
-    Layer(juce::File& file);
+    Layer(juce::File file);
     bool operator==(const Layer& other);
+    
+    juce::File& getFile();
+    
 private:
-    juce::File& layerFile;
+    juce::File layerFile;
 };
+
 
 class Project {
 public:
+    
+    Project();
+    
     /**
      Create a new Project.
      @throws Invalid mixdownFile exception if mixdownFile is a directory.
@@ -30,13 +37,41 @@ public:
      */
     Project(juce::File& mixdownFile);
     
+    /**
+     Return the name of this Project, which is based on its mixdown.
+     */
+    juce::String getName();
+    
+    /**
+     Retrieve this Project's mixdown file.
+     @return A mixdown file.
+     */
+    juce::File& getMixdownFile();
+    
+    /**
+     Retrieve the directory where this Project's Layers live.
+     @return A directory.
+     */
+    juce::File getLayerDirectory();
+    
+    /**
+     Creates and returns a new layer for this Project.
+     */
+    juce::File createNewLayer();
+    
+    /**
+     Return the number of Layers within this Project.
+     */
+    int getNumLayers();
+    
     // The layers which this Project contains. Open for manipulation from outsiders,
     // at least for now, to make for ease of use.
     juce::Array<Layer> layers;
     
 private:
-    juce::File& mixdownFile;
+    juce::File mixdownFile;
 };
+
 
 /**
  Utilities for generating and managing collections of projects.
@@ -46,6 +81,11 @@ public:
     /**
      Generate Projects from a given mixdown folder. Assumes that the folder specified has mixdown audio files in its root
      and layers for each project in subfolders with names identicle to their associated mixdown file (minus the file extension).
+     
+     For example, with a mixdown named "mixd.wav", we expect a subfolder within "mixd.wav"'s containing folder to be named
+     "mixd/" and contain the audio layers for the mixd project. If there is no such subfolder, it is assumed that this project
+     has no layers (yet).
+     
      @param mixdownFolder   The folder to generate mixdowns from.
      @return    A list of Projects found in given directory.
      */

--- a/Source/ProjectManagement.h
+++ b/Source/ProjectManagement.h
@@ -16,6 +16,7 @@
 class Layer {
 public:
     Layer(juce::File file);
+    
     bool operator==(const Layer& other);
     
     juce::File& getFile();
@@ -58,6 +59,8 @@ public:
      Creates and returns a new layer for this Project.
      */
     juce::File createNewLayer();
+    
+    juce::File getLastLayerFile();
     
     /**
      Return the number of Layers within this Project.


### PR DESCRIPTION
Tied together recording and playback components. I realized while doing so that the better architecture would have been to have recording and playback under one unifying component (that was more specialized than our MainComponent), but given time restraints, I chose bad practice over redesigning. The "bad practice" is tight coupling between components through bi-directional pointers.

With these changes, recording triggers effect playback (and vice versa) in a way which should hopefully be intuitive upon messing around with it. The only potentially unintuitive behavior I see is that if you start recording and skip to a different project, you will stay in "recording mode" but will start recording for the new project—that is, a new recording will be started immediately. Though currently a bit quirky, I think this could be a nice feature when paired with future features.

Padding is now automatically added to the start of recordings for easy alignment.

@Tuanthai4444, I also removed the file selector's default setting, since doing so enabled me to jump right to the folder I had last opened, which was pretty convenient for testing. I'm not sure if this will behave the same on Windows, but I wouldn't be surprised if it does.