### PR TITLE
Rearrange GUI elements for increased intuitiveness

### DIFF
--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -81,12 +81,12 @@ void MainComponent::resized() {
     using Track = juce::Grid::TrackInfo;
     using Fr = juce::Grid::Fr;
     
-    grid.templateRows    = { Track (Fr (1)), Track (Fr (2)) };
+    grid.templateRows    = { Track (Fr (2)), Track (Fr (1)) };
     grid.templateColumns = { Track (Fr (4)), Track (Fr (3)) };
     
     grid.items = {
-        juce::GridItem(layerRecorderComp), juce::GridItem(audioSetupComp),
-        juce::GridItem(mixdownFolderComp)
+        juce::GridItem(mixdownFolderComp), juce::GridItem(audioSetupComp),
+        juce::GridItem(layerRecorderComp)
     };
     
     auto rect = getLocalBounds();

--- a/Source/MixdownFolder.cpp
+++ b/Source/MixdownFolder.cpp
@@ -397,14 +397,15 @@ void MixdownFolderComp::resized() {
     
     auto area = getLocalBounds();
     
+    fileButton.setBounds(area.removeFromTop(41).reduced(8));
+
     // playback thumbnail and slider
     auto r = area.removeFromTop(165);
     tn->setBounds(r.removeFromTop(140));
     auto zoom = r.removeFromTop(25);
-    zoomSlider.setBounds(zoom);
+    zoomSlider.setBounds(zoom);    
     
     //Scaled to the parent window view
-    fileButton.setBounds(area.removeFromTop(41).reduced(8));
     fileBoxMenu.setBounds(area.removeFromTop(41).reduced(8));
     
     // transport buttons
@@ -421,9 +422,7 @@ void MixdownFolderComp::resized() {
     };
     
     prevNextGrid.setGap(juce::Grid::Px(12));
-    
     prevNextGrid.performLayout(area.removeFromTop(80).reduced(8));
-    
 }
 
 


### PR DESCRIPTION
I thought I would rearrange the elements a bit to be more intuitively aligned with workflow. Is this effective?

<img width="998" alt="Screen Shot 2021-05-31 at 3 36 06 PM" src="https://user-images.githubusercontent.com/22921007/120246923-92100000-c226-11eb-94d1-9da196cc9d95.png">